### PR TITLE
Show "dog" on hover of picture

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,6 @@
         </p>
         <a href="https://rundowndemon.github.io">this is link to robin's page</a>
 <br><br>
-        <img src="https://icatcare.org/app/uploads/2018/06/Layer-1704-1920x840.jpg" alt="dog" style="width:400px;height:200px;">
+        <img src="https://icatcare.org/app/uploads/2018/06/Layer-1704-1920x840.jpg" alt="dog" title="dog" style="width:400px;height:200px;">
     </body>
 </html>


### PR DESCRIPTION
added `title="dog"` to cat picture, because firefox doesn't show alt text on hover.